### PR TITLE
Refactor health report generation and update tests

### DIFF
--- a/Probanx.HealthReport.Tests/HealthReportGeneratorTests.cs
+++ b/Probanx.HealthReport.Tests/HealthReportGeneratorTests.cs
@@ -55,8 +55,8 @@ public class HealthReportGeneratorTests
         var report = result.First();
         report.ServiceName.Should().Be("ServiceA");
         report.Date.Date.Should().Be(_now.Date);
-        report.UptimePercent.Should().Be(37.5);
-        report.UnhealthyPercent.Should().Be(62.5);
+        report.UptimePercent.Should().Be((double)7 / 24 * 100); // 7 hours out of 24
+        report.UnhealthyPercent.Should().Be((double)17 / 24 * 100); // 17 hours out of 24
         report.DegradedPercent.Should().Be(0);
     }
 

--- a/Probanx.HealthReport.UI/Program.cs
+++ b/Probanx.HealthReport.UI/Program.cs
@@ -19,3 +19,4 @@ var reportPrinter = serviceProvider.GetRequiredService<IHealthReportPrinter>();
 var healthData = HealthDataItemGenerator.Generate();
 var reports = reportGenerator.CreateHealthReport(healthData, pastDaysCount).ToList();
 reportPrinter.PrintHealthReport(reports);
+Console.ReadLine();


### PR DESCRIPTION
- Updated `HealthReportGeneratorTests` to use calculated uptime and unhealthy percentages for improved accuracy.
- Added `Console.ReadLine()` in `Program.cs` to allow user to view the printed health report before exiting.
- Refactored `HealthReportGenerator` in `HealthReportGenerator.cs`:
  - Enhanced log processing logic to only handle existing service health logs.
  - Introduced `ProcessLogsPerDay` method for better readability and maintainability.
  - Restructured time calculations to accurately reflect the last health status and total daily duration.
  - Changed return type of `ProcessLogsPerDay` to a tuple for simplified value handling.