### PR TITLE
Add UnavailablePercent to health report calculations

### DIFF
--- a/Probanx.HealthReport.Tests/HealthReportPrinterTests.cs
+++ b/Probanx.HealthReport.Tests/HealthReportPrinterTests.cs
@@ -21,7 +21,7 @@ public class HealthReportPrinterTests
     public void PrintHealthReport_ShouldLogUnavailableMessage_WhenReportDataIsUnavailable()
     {
         // Arrange
-        var report = new ServiceReport("ServiceA", DateTimeOffset.UtcNow, TimeSpan.Zero, 0, 0, 0);
+        var report = new ServiceReport("ServiceA", DateTimeOffset.UtcNow, TimeSpan.Zero, 0, 0, 0, 100);
         var reports = new List<ServiceReport> { report };
 
         // Act
@@ -38,7 +38,7 @@ public class HealthReportPrinterTests
     public void PrintHealthReport_ShouldLogCorrectMessage_WhenReportDataIsAvailable()
     {
         // Arrange
-        var report = new ServiceReport("ServiceA", DateTimeOffset.UtcNow, TimeSpan.FromHours(1), 50, 30, 20);
+        var report = new ServiceReport("ServiceA", DateTimeOffset.UtcNow, TimeSpan.FromHours(1), 50, 30, 20, 0);
         var reports = new List<ServiceReport> { report };
 
         // Act
@@ -46,21 +46,22 @@ public class HealthReportPrinterTests
 
         // Assert
         _logger.Received(1).LogInformation(
-            "Service name = {serviceName}; Date = {date}; Uptime = {uptime}; UptimePercent = {uptimePercent}; UnhealthyPercent = {unhealthyPercent}; DegradedPercent = {degradedPercent}",
+            "Service name = {serviceName}; Date = {date}; Uptime = {uptime}; UptimePercent = {uptimePercent}; UnhealthyPercent = {unhealthyPercent}; DegradedPercent = {degradedPercent}; UnavailablePercent = {unavailablePercent}",
             "ServiceA",
             $"{report.Date:D}",
             "1:00:00",
             "50.00%",
             "30.00%",
-            "20.00%");
+            "20.00%",
+            "0.00%");
     }
 
     [Test]
     public void PrintHealthReport_ShouldLogMultipleMessages_WhenMultipleReportsAreProvided()
     {
         // Arrange
-        var report1 = new ServiceReport("ServiceA", DateTimeOffset.UtcNow, TimeSpan.FromHours(1), 50, 30, 20);
-        var report2 = new ServiceReport("ServiceB", DateTimeOffset.UtcNow, TimeSpan.Zero, 0, 0, 0);
+        var report1 = new ServiceReport("ServiceA", DateTimeOffset.UtcNow, TimeSpan.FromHours(1), 50, 30, 20, 0);
+        var report2 = new ServiceReport("ServiceB", DateTimeOffset.UtcNow, TimeSpan.Zero, 0, 0, 0, 100);
         var reports = new List<ServiceReport> { report1, report2, };
 
         // Act
@@ -68,13 +69,14 @@ public class HealthReportPrinterTests
 
         // Assert
         _logger.Received(1).LogInformation(
-            "Service name = {serviceName}; Date = {date}; Uptime = {uptime}; UptimePercent = {uptimePercent}; UnhealthyPercent = {unhealthyPercent}; DegradedPercent = {degradedPercent}",
+            "Service name = {serviceName}; Date = {date}; Uptime = {uptime}; UptimePercent = {uptimePercent}; UnhealthyPercent = {unhealthyPercent}; DegradedPercent = {degradedPercent}; UnavailablePercent = {unavailablePercent}",
             "ServiceA",
             $"{report1.Date:D}",
             "1:00:00",
             "50.00%",
             "30.00%",
-            "20.00%");
+            "20.00%",
+            "0.00%");
 
         _logger.Received(1).LogInformation(
             "Health data for Service name = {serviceName} for Date = {date} is Unavailable",

--- a/Probanx.HealthReport/HealthReportPrinter.cs
+++ b/Probanx.HealthReport/HealthReportPrinter.cs
@@ -18,7 +18,7 @@ public class HealthReportPrinter : IHealthReportPrinter
         foreach (var report in reports)
         {
             if (report.Uptime == TimeSpan.Zero &&
-                report is { UptimePercent: 0, UnhealthyPercent: 0, DegradedPercent: 0 })
+                report is { UptimePercent: 0, UnhealthyPercent: 0, DegradedPercent: 0, UnavailablePercent: 100 })
             {
                 _logger.LogInformation(
                     "Health data for Service name = {serviceName} for Date = {date} is Unavailable",
@@ -28,13 +28,14 @@ public class HealthReportPrinter : IHealthReportPrinter
             else
             {
                 _logger.LogInformation(
-                    "Service name = {serviceName}; Date = {date}; Uptime = {uptime}; UptimePercent = {uptimePercent}; UnhealthyPercent = {unhealthyPercent}; DegradedPercent = {degradedPercent}",
+                    "Service name = {serviceName}; Date = {date}; Uptime = {uptime}; UptimePercent = {uptimePercent}; UnhealthyPercent = {unhealthyPercent}; DegradedPercent = {degradedPercent}; UnavailablePercent = {unavailablePercent}",
                     report.ServiceName,
                     $"{report.Date:D}",
                     $"{report.Uptime:g}",
                     $"{report.UptimePercent:N}%",
                     $"{report.UnhealthyPercent:N}%",
-                    $"{report.DegradedPercent:N}%");
+                    $"{report.DegradedPercent:N}%",
+                    $"{report.UnavailablePercent:N}%");
             }
         }
     }

--- a/Probanx.HealthReport/Models/ServiceReport.cs
+++ b/Probanx.HealthReport/Models/ServiceReport.cs
@@ -1,3 +1,3 @@
 ﻿namespace Probanx.HealthReport.Models;
 
-public record ServiceReport(string ServiceName, DateTimeOffset Date, TimeSpan Uptime, double UptimePercent, double UnhealthyPercent, double DegradedPercent);
+public record ServiceReport(string ServiceName, DateTimeOffset Date, TimeSpan Uptime, double UptimePercent, double UnhealthyPercent, double DegradedPercent, double UnavailablePercent);


### PR DESCRIPTION
Updated HealthReportGeneratorTests and HealthReportPrinterTests to incorporate UnavailablePercent in service reports. Modified HealthReportGenerator to handle new metric and adjusted ServiceReport class to include UnavailablePercent property. Ensured all relevant tests validate the expected outcomes based on updated health data.